### PR TITLE
Add API for excluding specific machines from quality debuff

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1,0 +1,13 @@
+if InvertedQuality == nil then
+	InvertedQuality = {
+		entity = {}
+	}
+
+	function InvertedQuality.ignore_machine(entity_name)
+		if InvertedQuality.entity[entity_name] then
+			InvertedQuality.entity[entity_name].ignore = true
+		else
+			InvertedQuality.entity[entity_name] = {ignore=true}
+		end
+	end
+end

--- a/data.lua
+++ b/data.lua
@@ -1,3 +1,5 @@
+require("api")
+
 require("prototypes.categories")
 require("prototypes.entity.meltdown-facility")
 require("prototypes.entity.downgrade-port")
@@ -6,3 +8,5 @@ require("prototypes.quality")
 require("prototypes.recipe")
 require("prototypes.entity.entity")
 require("prototypes.technology")
+
+require("prototypes.compat.aai-industry")

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
     "name": "Inverted-Quality",
     "author": "thesixthroc",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "title": "Inverted Quality (Beta)",
     "description": "Inverts the Quality system to negative tiers (positive tiers are removed).\n\nCrafting items has a two-thirds chance to reduce their quality by one tier. Items in the lowest tier are nonfunctional.\n\nThe new Downgrade Port allows high-quality items to be used in low-quality recipes, and the Meltdown Facility allows the melting down of low-quality items back into Normal base materials.\n\nMap sliders for higher resources are recommended.",
     "contact": "Discord: thesixthroc",

--- a/prototypes/compat/aai-industry.lua
+++ b/prototypes/compat/aai-industry.lua
@@ -1,0 +1,3 @@
+if mods["aai-industry"] then
+	InvertedQuality.ignore_machine("industrial-furnace")
+end

--- a/prototypes/override-final/base-quality.lua
+++ b/prototypes/override-final/base-quality.lua
@@ -8,6 +8,9 @@ for _, type in pairs({
 	"lab",
 }) do
 	for name, e in pairs(data.raw[type]) do
+		if InvertedQuality.entity[e.name] and InvertedQuality.entity[e.name].ignore == true then
+			goto continue
+		end
 		if not e.effect_receiver then
 			e.effect_receiver = {}
 		end
@@ -18,5 +21,6 @@ for _, type in pairs({
 		-- if name == "Inverted-Quality-meltdown-facility" or name == "Inverted-Quality-downgrade-port" then
 		-- 	e.effect_receiver.base_effect.quality = -100
 		-- end
+		::continue::
 	end
 end


### PR DESCRIPTION
I noticed when adding this to a save that machines added by other mods which are _effectively_ furnaces would have the quality "debuff" applied to them. This is a simple change to add support for disabling that without manually undoing the change, which is error-prone. An example of using this can be seen in prototypes/compat/inverted-quality.lua [here](https://github.com/SafTheLamb/fm-alloy-smelting/commit/fc7a82a11c1814825badf9fc0287bf8c1be6ad6b#diff-a745222667b9fa2c0328eee5e7e55b56144239833dd5673b92eef3b0caabc4cd), compared to inverted-quality-final.lua, which would erase any base quality being added.

This change also takes any existing inherent quality bonus into account.